### PR TITLE
Add a flag for specifying the remote system name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,14 @@ impl Flake {
     pub async fn build(
         self,
         on: Box<dyn NixOperatingSystem>,
+        config_name: Option<&str>,
     ) -> Result<SystemConfiguration, anyhow::Error> {
-        let path = on.build_flake(&self).await?;
+        let (path, system_name) = on.build_flake(&self, config_name).await?;
         Ok(SystemConfiguration {
             source: self,
             path,
             system: on,
+            system_name,
         })
     }
 }
@@ -84,15 +86,17 @@ pub struct SystemConfiguration {
     source: Flake,
     path: PathBuf,
     system: Box<dyn NixOperatingSystem>,
+    system_name: String,
 }
 
 impl fmt::Debug for SystemConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "<src:{:?}|built:{:?}>",
+            "<src:{:?}|built:{:?}#{}>",
             self.source.resolved_path(),
-            self.path
+            self.path,
+            self.system_name
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ struct Opts {
 
     /// The host that we deploy to
     to: String,
+
+    /// Name of the configuration to deploy. Defaults to the remote hostname.
+    #[clap(long)]
+    config_name: Option<String>,
 }
 
 impl Opts {
@@ -53,7 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .with_context(|| format!("Connecting to {:?}", &opts.to))?,
     );
     log::info!("Building flake", {on: flavor.as_ref(), flake: flake.resolved_path()});
-    let built = flake.build(flavor).await?;
+    let built = flake.build(flavor, opts.config_name.as_deref()).await?;
 
     log::info!("Checking system health", { cfg: &built });
     built.preflight_check().await?;

--- a/src/os.rs
+++ b/src/os.rs
@@ -24,8 +24,13 @@ pub trait NixOperatingSystem: ToValue {
     async fn preflight_check(&self) -> Result<(), anyhow::Error>;
 
     /// Builds a system configuration closure from the flake and
-    /// returns the path to the built closure.
-    async fn build_flake(&self, flake: &crate::Flake) -> Result<PathBuf, anyhow::Error>;
+    /// returns the path to the built closure and the name of the
+    /// system that it was built for.
+    async fn build_flake(
+        &self,
+        flake: &crate::Flake,
+        config_name: Option<&str>,
+    ) -> Result<(PathBuf, String), anyhow::Error>;
 
     /// Sets the built system as the current "system" profile
     /// generation, without activation.


### PR DESCRIPTION
Fixes #1. Occasionally, the remote system name is not the one that the flake expects, so it's good to be able to pick another.