### PR TITLE
Collect failed "test" units & document deploy failure

### DIFF
--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -194,6 +194,7 @@ impl NixOperatingSystem for Nixos {
             &unit_name,
             "--wait",
             "--quiet",
+            "--collect",
             "--pipe",
             // Fix perl complaining about bad locale settings:
             "--setenv=LC_ALL=C",


### PR DESCRIPTION
I have gotten tired of the `systemctl reset-failed` dance on systems where the only failed unit is the `test` step from deploy-flake. This ensures that systemd will collect the failed deploy attempt and only leaves units that are actually in need of operator attention.

The logs for the deploy attempt can still be inspected with journalctl - systemd will only collect things like resources and exit statuses.

This PR also adds some docs for what to do if a deploy fails.