### PR TITLE
Deploy to multiple targets, in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -138,6 +149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -194,6 +216,12 @@ checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -292,6 +320,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -534,6 +568,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,10 +671,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "futures",
  "openssh",
  "serde",
  "serde_json",
@@ -117,6 +118,95 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -334,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +601,12 @@ checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,48 @@
 [package]
-edition = '2018'
-name = "deploy-flake"
-version = "0.0.1-dev"
 authors = ["Andreas Fuchs <asf@boinkor.net>"]
-license = "MIT"
-repository = "https://github.com/antifuchs/deploy-flake"
-readme = "README.md"
 description = "Deploy a nix flake to a remote system"
 documentation = "https://docs.rs/deploy-flake"
+edition = "2018"
+license = "MIT"
+name = "deploy-flake"
+readme = "README.md"
+repository = "https://github.com/antifuchs/deploy-flake"
+version = "0.0.1-dev"
+
+[metadata]
+[metadata.template_ci]
+[metadata.template_ci.clippy]
+allow_failure = false
+version = "stable"
+[badges]
+[badges.maintenance]
+status = "passively-maintained"
+
+[badges.travis-ci]
+branch = "master"
+repository = "antifuchs/deploy-flake"
 
 [[bin]]
 name = "deploy-flake"
 path = "src/main.rs"
 
-[badges]
-travis-ci = { repository = "antifuchs/deploy-flake", branch = "master" }
-maintenance = { status = "passively-maintained" }
-
-[package.metadata.template_ci.clippy]
-allow_failure = false
-version = "stable"
-
 [dependencies]
-clap = { version = "3.1.8", features = ["derive"] }
 anyhow = "1.0.56"
-serde_json = "1.0.79"
-serde = { version = "1.0.136", features = ["derive"] }
-openssh = "0.8.1"
-tokio = { version = "1.16.1", features = ["full"] }
 async-trait = "0.1.53"
+openssh = "0.8.1"
+serde_json = "1.0.79"
 tracing = "0.1.32"
 tracing-subscriber = "0.3.10"
+url = "*"
+
+[dependencies.clap]
+features = ["derive"]
+version = "3.1.8"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0.136"
+
+[dependencies.tokio]
+features = ["full"]
+version = "1.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,6 @@ name = "deploy-flake"
 readme = "README.md"
 repository = "https://github.com/antifuchs/deploy-flake"
 version = "0.0.1-dev"
-
-[metadata]
-[metadata.template_ci]
-[metadata.template_ci.clippy]
-allow_failure = false
-version = "stable"
 [badges]
 [badges.maintenance]
 status = "passively-maintained"
@@ -29,6 +23,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.56"
 async-trait = "0.1.53"
+futures = "*"
 openssh = "0.8.1"
 serde_json = "1.0.79"
 tracing = "0.1.32"
@@ -46,3 +41,9 @@ version = "1.0.136"
 [dependencies.tokio]
 features = ["full"]
 version = "1.16.1"
+
+[metadata]
+[metadata.template_ci]
+[metadata.template_ci.clippy]
+allow_failure = false
+version = "stable"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Flake {
 
     #[instrument(level = "INFO", "Building flake", err)]
     pub async fn build(
-        self,
+        &self,
         on: Box<dyn NixOperatingSystem>,
         config_name: Option<&str>,
     ) -> Result<SystemConfiguration, anyhow::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,42 @@ use anyhow::Context;
 use clap::Parser;
 use deploy_flake::{Flake, Flavor};
 use openssh::{KnownHosts, Session};
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
+use url::Url;
+
+#[derive(Debug)]
+struct Destination {
+    os_flavor: Flavor,
+    hostname: String,
+    config_name: Option<String>,
+}
+
+impl FromStr for Destination {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = Url::parse(s) {
+            // we have a URL, let's see if it matches something we can deal with:
+            match (url.scheme(), url.host_str(), url.path()) {
+                (scheme, Some(hostname), path) if scheme == "nixos" => Ok(Destination {
+                    os_flavor: Flavor::Nixos,
+                    hostname: hostname.to_string(),
+                    config_name: path
+                        .strip_prefix('/')
+                        .filter(|path| path.len() != 0)
+                        .map(String::from),
+                }),
+                _ => anyhow::bail!("Unable to parse {s}"),
+            }
+        } else {
+            Ok(Destination {
+                os_flavor: Flavor::Nixos,
+                hostname: s.to_string(),
+                config_name: None,
+            })
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 #[clap(author = "Andreas Fuchs <asf@boinkor.net>")]
@@ -13,16 +48,9 @@ struct Opts {
     #[clap(long, default_value = ".")]
     flake: PathBuf,
 
-    /// The operating system flavor to deploy to.
-    #[clap(long, default_value_t)]
-    os_flavor: Flavor,
-
-    /// The host that we deploy to
-    to: String,
-
-    /// Name of the configuration to deploy. Defaults to the remote hostname.
-    #[clap(long)]
-    config_name: Option<String>,
+    /// The destinations that we deploy to
+    #[clap(parse(try_from_str))]
+    to: Vec<Destination>,
 }
 
 #[tokio::main]
@@ -35,27 +63,31 @@ async fn main() -> Result<(), anyhow::Error> {
     let flake = Flake::from_path(&opts.flake)?;
     log::debug!(?flake, "Flake metadata");
 
-    log::info!(flake=flake.resolved_path(), host=?opts.to, "Copying");
-    flake.copy_closure(&opts.to)?;
+    for destination in opts.to {
+        log::info!(flake=?flake.resolved_path(), host=?destination.hostname, "Copying");
+        flake.copy_closure(&destination.hostname)?;
 
-    log::debug!(to=?opts.to, "Connecting");
-    let flavor = opts.os_flavor.on_connection(
-        &opts.to,
-        Session::connect(&opts.to, KnownHosts::Strict)
-            .await
-            .with_context(|| format!("Connecting to {:?}", &opts.to))?,
-    );
-    log::info!(flake=?flake.resolved_path(), host=?opts.to, "Building");
-    let built = flake.build(flavor, opts.config_name.as_deref()).await?;
+        log::debug!(to=?destination.hostname, "Connecting");
+        let flavor = destination.os_flavor.on_connection(
+            &destination.hostname,
+            Session::connect(&destination.hostname, KnownHosts::Strict)
+                .await
+                .with_context(|| format!("Connecting to {:?}", &destination.hostname))?,
+        );
+        log::info!(flake=?flake.resolved_path(), host=?destination.hostname, config=?destination.config_name, "Building");
+        let built = flake
+            .build(flavor, destination.config_name.as_deref())
+            .await?;
 
-    log::info!("Checking system health");
-    built.preflight_check().await?;
+        log::info!("Checking system health");
+        built.preflight_check().await?;
 
-    log::info!(configuration=?built.configuration(), host=?built.on(), system_name=?built.for_system(), "Testing");
-    built.test_config().await?;
-    // TODO: rollbacks, maybe?
-    log::info!(configuration=?built.configuration(), host=?built.on(), system_name=?built.for_system(), "Activating");
-    built.boot_config().await?;
+        log::info!(configuration=?built.configuration(), host=?built.on(), system_name=?built.for_system(), "Testing");
+        built.test_config().await?;
+        // TODO: rollbacks, maybe?
+        log::info!(configuration=?built.configuration(), host=?built.on(), system_name=?built.for_system(), "Activating");
+        built.boot_config().await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
I had a bit of time today & reworked the deploy process to be parallelize-able and to run in parallel. 

This PR

* Changes the commandline interface a bit, so that you can (optionally) specify the configuration and OS flavor to deploy on each host
* Makes the commandline-specified destinations a vector
* Runs the deploy in parallel

This isn't fully amazing yet: The output of each deploy is interleaved with each other, which means that you may get _really_ confused about what happened. However, it's a huge time saver on deploys that succeed. So.. hm. I'm inclined to merge this now and improve it later.

Also, I have no idea what happens if one deploy fails. That's an interesting exercise for later (: