### PR TITLE
Use tracing-indicatif for non-clobbered log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +625,30 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -916,10 +949,14 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "deploy-flake"
 version = "0.0.1-dev"
 dependencies = [
@@ -99,6 +112,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-indicatif",
  "tracing-subscriber",
  "url",
 ]
@@ -122,6 +136,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
@@ -288,6 +308,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +502,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -844,6 +888,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-indicatif"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a821f828aa086509b0e6edcf376f8b03ded994a5d3e052e14236d4113f3b1974"
+dependencies = [
+ "indicatif",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +944,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "*"
 openssh = "0.9.9"
 serde_json = "1.0.89"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "*"
 tracing-indicatif = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.89"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = "*"
+tracing-indicatif = "0.2.2"
 
 [dependencies.clap]
 features = ["derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl Flake {
     }
 
     /// Synchronously copies the store path closure to the destination host.
-    #[instrument(err)]
+    #[instrument(skip(self), err)]
     pub fn copy_closure(&self, to: &str) -> Result<(), anyhow::Error> {
         let result = Command::new("nix-copy-closure")
             .args([to, self.resolved_path()])
@@ -95,13 +95,16 @@ impl SystemConfiguration {
 
     #[instrument(skip(self) err)]
     pub async fn boot_config(&self) -> Result<(), anyhow::Error> {
-        log::debug!("Attempting to activate boot configuration (dry-run)");
+        log::event!(
+            log::Level::DEBUG,
+            "Attempting to activate boot configuration (dry-run)"
+        );
         self.system
             .update_boot_for_config(&self.path)
             .await
             .context("Trial run of boot activation failed. No cleanup necessary.")?;
 
-        log::debug!("Setting system profile");
+        log::event!(log::Level::DEBUG, "Setting system profile");
         self.system
             .set_as_current_generation(&self.path)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,12 +88,12 @@ pub struct SystemConfiguration {
 }
 
 impl SystemConfiguration {
-    #[instrument(skip(self), fields(on=?self.on(), configuration=?self.configuration()), err)]
+    #[instrument(skip(self) err)]
     pub async fn test_config(&self) -> Result<(), anyhow::Error> {
         self.system.test_config(&self.path).await
     }
 
-    #[instrument(skip(self), fields(on=?self.on(), configuration=?self.configuration()), err)]
+    #[instrument(skip(self) err)]
     pub async fn boot_config(&self) -> Result<(), anyhow::Error> {
         log::debug!("Attempting to activate boot configuration (dry-run)");
         self.system
@@ -111,7 +111,7 @@ impl SystemConfiguration {
             .context("Actually setting the boot configuration failed. To clean up, you'll have to reset the system profile.")
     }
 
-    #[instrument(level="DEBUG", skip(self), fields(on=?self.on(), configuration=?self.configuration()), err)]
+    #[instrument(level="DEBUG", skip(self) err)]
     pub async fn preflight_check(&self) -> Result<(), anyhow::Error> {
         self.system.preflight_check().await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl Flake {
     }
 
     /// Copies the store path closure to the destination host.
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self), fields(to), err)]
     pub async fn copy_closure(&self, to: &str) -> Result<(), anyhow::Error> {
         let mut cmd = Command::new("nix-copy-closure");
         cmd.args([to, self.resolved_path()]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
+                .compact()
                 .with_writer(indicatif_layer.get_fmt_writer()),
         )
         .with(indicatif_layer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,9 @@ struct Opts {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let indicatif_layer = tracing_indicatif::IndicatifLayer::new();
-    let filter = EnvFilter::from_default_env();
+    let filter = EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
     tracing_subscriber::registry()
         .with(filter)
         .with(tracing_subscriber::fmt::layer().with_writer(indicatif_layer.get_fmt_writer()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use deploy_flake::{Flake, Flavor};
 use openssh::{KnownHosts, Session};
 use std::{path::PathBuf, str::FromStr};
+use tracing_subscriber::prelude::*;
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -64,7 +65,11 @@ struct Opts {
 #[instrument(err)]
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    tracing_subscriber::fmt::init();
+    let indicatif_layer = tracing_indicatif::IndicatifLayer::new().with_max_progress_bars(3, None);
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(indicatif_layer.get_fmt_writer()))
+        .with(indicatif_layer)
+        .init();
 
     let opts: Opts = Opts::parse();
     log::trace!(cmdline = ?opts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[instrument(skip(flake, destination), fields(flake=?flake.resolved_path(), dest=?destination.hostname) err)]
+#[instrument(skip(flake, destination), fields(flake=flake.resolved_path(), dest=destination.hostname) err)]
 async fn deploy(flake: Flake, destination: Destination) -> Result<(), anyhow::Error> {
     log::info!(flake=?flake.resolved_path(), host=?destination.hostname, "Copying");
     flake.copy_closure(&destination.hostname)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
 #[instrument(skip(flake, destination), fields(flake=flake.resolved_path(), dest=destination.hostname) err)]
 async fn deploy(flake: Flake, destination: Destination) -> Result<(), anyhow::Error> {
     log::event!(log::Level::INFO, flake=?flake.resolved_path(), host=?destination.hostname, "Copying");
-    flake.copy_closure(&destination.hostname)?;
+    flake.copy_closure(&destination.hostname).await?;
 
     log::debug!("Connecting");
     let flavor = destination.os_flavor.on_connection(

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -100,7 +100,7 @@ impl Nixos {
 
 #[async_trait::async_trait]
 impl NixOperatingSystem for Nixos {
-    #[instrument(level = "DEBUG", err)]
+    #[instrument(level = "INFO", err)]
     async fn preflight_check(&self) -> Result<(), anyhow::Error> {
         let mut cmd = self.session.command("sudo");
         cmd.stdout(Stdio::piped());
@@ -127,7 +127,7 @@ impl NixOperatingSystem for Nixos {
             );
             anyhow::bail!("Can not deploy to an unhealthy system");
         }
-        log::event!(log::Level::INFO, ?status, "System is healthy");
+        log::event!(log::Level::DEBUG, ?status, "System is healthy");
         Ok(())
     }
 

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -1,6 +1,7 @@
+use crate::read_and_log_messages;
 use anyhow::Context;
 use openssh::{Command, Stdio};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, BufReader};
+use tokio::io::AsyncReadExt;
 use tracing as log;
 use tracing::instrument;
 
@@ -18,22 +19,6 @@ use crate::{NixOperatingSystem, Verb};
 pub struct Nixos {
     host: String,
     session: openssh::Session,
-}
-
-async fn read_and_log_messages(
-    stream: &str,
-    r: impl AsyncRead + Unpin,
-) -> Result<(), anyhow::Error> {
-    let br = BufReader::new(r);
-    let mut lines = br.lines();
-    while let Some(line) = lines
-        .next_line()
-        .await
-        .context("Unable to read next line")?
-    {
-        log::event!(log::Level::INFO, "{stream} {line}");
-    }
-    Ok(())
 }
 
 fn strip_shell_output(output: Output) -> String {


### PR DESCRIPTION
This addresses #15 by using tracing_indicatif to render progress bars, which attaches log messages to the trace span (and thus, progress bar) of the thing being worked on in the log message.

It's really pretty neat, but I feel like some stuff could still be improved:

- [x] program log output doesn't say which host it's from (instead, logs the silly `deploy_flake` module name
- [x] maybe there's still some bare output-chundering to stderr? I'm not sure!