### PR TITLE
Improve stdout/stderr logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,11 @@ pub(crate) async fn read_and_log_messages(
         .await
         .context("Unable to read next line")?
     {
-        log::event!(target: SUBPROCESS_LOG_TARGET, log::Level::INFO, "{stream} {line}");
+        log::event!(
+            target: SUBPROCESS_LOG_TARGET,
+            log::Level::INFO,
+            "{stream} {line}"
+        );
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ use std::{
 };
 use tokio::process::Command;
 
+/// The tracing target that's used to log messages emitted by
+/// subprocesses.
+pub const SUBPROCESS_LOG_TARGET: &str = "subprocess_log";
+
 /// All the important bits about a nix flake reference.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Flake {
@@ -39,7 +43,7 @@ pub(crate) async fn read_and_log_messages(
         .await
         .context("Unable to read next line")?
     {
-        log::event!(log::Level::INFO, "{stream} {line}");
+        log::event!(target: SUBPROCESS_LOG_TARGET, log::Level::INFO, "{stream} {line}");
     }
     Ok(())
 }

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -71,7 +71,7 @@ impl Nixos {
         Ok(strip_shell_output(output))
     }
 
-    #[instrument(level = "DEBUG", err)]
+    #[instrument(level = "DEBUG", fields(cmd), err)]
     async fn run_command<'s>(&self, mut cmd: Command<'s>) -> Result<(), anyhow::Error> {
         cmd.stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
This PR introduces a second logging layer filter, which formats stderr/stdout messages without fields/target information; this should make it much easier to tell what has gone wrong when a build/test/boot run fails.